### PR TITLE
Add the signup page + more auth

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,8 @@ app.secret_key = secrets.token_hex().encode()
 # Authentication setup
 login_manager = LoginManager()
 login_manager.init_app(app)
+login_manager.login_view = "auth.login"
+login_manager.login_message = "It appears you are not signed in. Please sign in here."
 
 @login_manager.user_loader
 def user_loader(user_id):

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -41,7 +41,14 @@ def login():
     hash.update(user.salt.encode())
     if user.password == hash.hexdigest():
         login_user(user, remember=remember)
-        return redirect("/")
+        
+        # Check if there is a next argument and save the value
+        redirect_url = request.args.get("next", None)
+
+        if redirect_url is None:
+            return redirect("/")
+        else:
+            return redirect(redirect_url)
     
     flash("Username or password may be correct")
     return redirect(url_for("auth.login"))

--- a/routes/reminders.py
+++ b/routes/reminders.py
@@ -67,6 +67,7 @@ def mark_reminder_incomplete_route(id):
     return redirect(url_for("lists.get_list", id=reminder.rem_list.id))
 
 @reminders_route.route("/edit/<int:id>", methods=["GET"])
+@login_required
 def edit_item(id):
     session = db.session
     current_item = session.execute(db.select(Todo).where(Todo.id == id)).scalar()

--- a/static/js/passwordHashing.js
+++ b/static/js/passwordHashing.js
@@ -1,18 +1,20 @@
 
 const userExists = async (callback) => {
-    let username = document.querySelector("#username").value;
-    const req = await fetch(`/auth/exists/${username}`, { method: 'GET'})
-    if (req.ok){
-        callback(undefined, true);
-    } else if (req.status==404) {
-        callback(undefined, false)
-    } else{
-        callback(Error("Code unknown"))
-    }
+    // This fucntions user checking has been disabled for the time being
+    // let username = document.querySelector("#username").value;
+    // const req = await fetch(`/auth/exists/${username}`, { method: 'GET'})
+    // if (req.ok){
+        // 
+    // } else if (req.status==404) {
+        // callback()
+    // } else{
+// 
+    // }
+    document.getElementById("hidden-name").value = document.getElementById("name").value;
+    callback();
 }
 
-const hashPasswdThenSubmit = async (err, issueProceeding) => {
-    if (err || issueProceeding) return;
+const hashPasswdThenSubmit = async () => {
     // SOme code here comes from mozilla
     const passwd8 = new TextEncoder().encode(`${document.getElementById("password").value}`);
     const hashArrayBuffer = await window.crypto.subtle.digest("SHA-256", passwd8);
@@ -26,7 +28,7 @@ const hashPasswdThenSubmit = async (err, issueProceeding) => {
     document.getElementById("main-form").submit()
 }
 
-const startLogin = () => hashPasswdThenSubmit(undefined, false);
+const startLogin = () => hashPasswdThenSubmit();
 const startSignup = () => userExists(hashPasswdThenSubmit);
 const enterKeyPress = (event) => { if (event.key == "Enter") document.getElementById("submit").click() };
 

--- a/static/js/signUpPageInteractivity.js
+++ b/static/js/signUpPageInteractivity.js
@@ -1,0 +1,56 @@
+let passwordLengthMet = false;
+let passwordMatches = false;
+
+const checkAllRequirements = () => {
+    const signUp = document.getElementById("submit");
+    if (passwordLengthMet && passwordMatches){ 
+        signUp.disabled = false;
+    } else{
+        signUp.disabled = true;    
+    }
+}
+
+const checkMatch = () => {
+    const confirm = document.querySelector("#confirm");
+    const passwd = document.querySelector("#password");
+    passwd.addEventListener("keyup", checkMatch);
+    if (passwd.value === confirm.value) {
+        passwordMatches = true;
+        confirm.style = ""
+        passwd.style = ""
+    } else {
+        passwordMatches = false;
+        confirm.style = "background-color: red"
+        passwd.style = "background-color: red"
+    }
+}
+
+const checkPasswordLength = (passwordBox) => {
+    // Currently only 8+ characters. This is terrible and I will (probably not) redo it
+    const requirements = document.getElementById("password-requirements");
+    if (passwordBox.target.value.length > 8){
+        passwordLengthMet = true;
+        requirements.style = "color: green;";
+    } else {
+        passwordLengthMet = false;
+        requirements.style = "";
+    }
+}
+
+const enterKeyHandler = (keyPressed) => {
+    if (keyPressed.key === "Enter") {
+        document.getElementById("submit").click()
+    }
+}
+
+const init = () => {
+    document.getElementById("password").addEventListener("keyup", checkPasswordLength);
+    document.getElementById("confirm").addEventListener("keyup", checkMatch);
+    setInterval(checkAllRequirements, 250)
+
+    for (const inputOf of document.querySelectorAll("input.text")){ 
+        inputOf.addEventListener("keypress", enterKeyHandler);
+    }
+}
+
+window.addEventListener("load", init);

--- a/static/signup.css
+++ b/static/signup.css
@@ -16,6 +16,6 @@ h2 {
     color: white;
 }
 
-label {
+label, p {
     color: white;
 }

--- a/templates/login.html
+++ b/templates/login.html
@@ -21,7 +21,7 @@
         <label for="password">Password:</label><br>
         <input type="password" id="password" name="password" placeholder="Password" autocomplete="current-password"><br><br>
         
-        <form action="{{url_for('auth.login')}}" method="post" id="main-form">
+        <form action="{{url_for('auth.login', next=request.args.get('next', None))}}" method="post" id="main-form">
             <input type="text" id="hiddenusername" name="username" hidden="true">
             <input type="text" id="hashpasswd" name="hashpasswd" hidden="true">
             <input type="checkbox" id="remember" name="remember" value="remember" checked>

--- a/templates/login.html
+++ b/templates/login.html
@@ -11,14 +11,15 @@
     <video autoplay loop muted>
         <source src="/static/resources/wave.mp4" type="video/mp4">
     </video>
+    <a href="{{ url_for('auth.signup') }}"><button>Sign-Up</button></a>
     <div id="loginForm">
         <h2>Log In</h2>
 
         <p style="background-color: red;">{{ ' '.join(get_flashed_messages()) }}</p>
         <label for="username">Username:</label><br>
-        <input type="text" id="username" name="username" placeholder="Username"><br>
+        <input type="text" id="username" name="username" placeholder="Username" autocomplete="username off"><br>
         <label for="password">Password:</label><br>
-        <input type="password" id="password" name="password" placeholder="Password"><br><br>
+        <input type="password" id="password" name="password" placeholder="Password" autocomplete="current-password"><br><br>
         
         <form action="{{url_for('auth.login')}}" method="post" id="main-form">
             <input type="text" id="hiddenusername" name="username" hidden="true">

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -13,13 +13,24 @@
     <div id="signupForm">
         <h2>Sign Up</h2>
 
-        <form action="">
         <label for="username">Username:</label><br>
         <input type="text" id="username" name="username" placeholder="Username"><br>
-        <label for="password">Password:</label><br>
-        <input type="password" id="password" name="password" placeholder="Password"><br><br>
-        <input type="submit" value="Submit">
+        <label for="name">Name:</label><br>
+        <input type="text" id="name" name="name" placeholder="Name"><br><br>
+
+        <label for="password">Password:</label>
+        <p id="password-requirements">Must be 8 characters long.</p>
+        <input type="password" id="password" name="password" placeholder="Password"><br>
+        <label for="password">Confirm Password:</label><br>
+        <input type="password" id="confirm" name="confirm" placeholder="Password"><br><br>
+
+        <form action="{{ url_for('auth.signup') }}" method="post">
+            <input type="text" id="hidden-username" name="username" hidden="true">
+            <input type="text" id="hashpasswd" name="hashpasswd" hidden="true">
+            <input type="text" id="hidden-name" name="name" hidden="true">
         </form> 
+        <input type="submit" value="Submit">
+       
     </div>
 </body>
 </html>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -10,6 +10,7 @@
     <video autoplay loop muted>
         <source src="/static/resources/wave.mp4" type="video/mp4">
     </video>
+    <a href="{{ url_for('auth.login') }}"><button>Sign-In</button></a>
     <div id="signupForm">
         <h2>Sign Up</h2>
 
@@ -24,13 +25,14 @@
         <label for="password">Confirm Password:</label><br>
         <input type="password" id="confirm" name="confirm" placeholder="Password"><br><br>
 
-        <form action="{{ url_for('auth.signup') }}" method="post">
-            <input type="text" id="hidden-username" name="username" hidden="true">
+        <form action="{{ url_for('auth.signup') }}" method="post" id="main-form">
+            <input type="text" id="hiddenusername" name="username" hidden="true">
             <input type="text" id="hashpasswd" name="hashpasswd" hidden="true">
             <input type="text" id="hidden-name" name="name" hidden="true">
         </form> 
-        <input type="submit" value="Submit">
-       
+        <input type="submit" value="Submit" id="submit" disabled="true" onclick="startSignup()">
     </div>
+    <script src="/static/js/signUpPageInteractivity.js"></script>
+    <script src="/static/js/passwordHashing.js"></script>
 </body>
 </html>

--- a/templates/todolist.html
+++ b/templates/todolist.html
@@ -33,8 +33,7 @@
 
     <div id="currentList">
         <h2 class="app-name"> Things-To-Do </h2>
-
-            <button class="sign-out" type="button"> Sign Out </button>
+            <a href="{{ url_for('auth.logout')}}"><button class="sign-out" type="button"> Sign Out </button></a>
             <button class="create-list" type="button"> Create List </button>
 
             <h2> {{list.name}} </h2>

--- a/tests/functional/test_unauthed_access.py
+++ b/tests/functional/test_unauthed_access.py
@@ -46,32 +46,46 @@ def client_authed():
         yield client
 
 
-# Test unauthenticated use of routes
+# Test unauthenticated use of routes. They used to test for code 401 but they now test for a redirect to the login page
 
 def test_unauthenticated_delete_reminders(client):
-    """Checks to see if a code 401 is sent when deleting a reminder when not signed in """
+    """Checks to see if a code 302 is sent when deleting a reminder when not signed in """
     res = client.get("/reminders/remove/1")
-    assert res.status_code == 401 # No permission to use route
+    assert res.status_code == 302 # No permission to use route
+
+    res = client.get(f"/auth/login") # test that the message shows
+    assert b"It appears you are not signed in. Please sign in here." in res.data
 
 def test_unauthenticated_mark_complete_incomplete(client):
-    """ Tests to make sure a code 401 is returned when trying to mark a reminder as complete/incomplete when not signed in """
+    """ Tests to make sure a code 302 is returned when trying to mark a reminder as complete/incomplete when not signed in """
     res = client.post(f"/reminders/complete/1")
-    assert res.status_code == 401 # Reminder not able to be completed
+    assert res.status_code == 302 # Reminder not able to be completed
+    res = client.get(f"/auth/login")
+    assert b"It appears you are not signed in. Please sign in here." in res.data
 
     res = client.post(f"/reminders/de-complete/1")
-    assert res.status_code == 401 # Reminder not able to be decompleted
+    assert res.status_code == 302 # Reminder not able to be decompleted
+    res = client.get(f"/auth/login")
+    assert b"It appears you are not signed in. Please sign in here." in res.data
+
 
 def test_unauthenticated_edit_get_and_post(client):
     """ Test that an unauthenticated in user can neither get the edit page or complete a reminder edit """
     res = client.get("/reminders/edit/1")
-    assert res.status_code == 401 # No permission to edit that item
+    assert res.status_code == 302 # No permission to edit that item
+    res = client.get(f"/auth/login")
+    assert b"It appears you are not signed in. Please sign in here." in res.data
+
 
     res = client.post("/reminders/edit/1/completion", data={
         "item-name": "The Great Gig In The Sky",
         "description": "Immigrant Song",
         "deadline": "1977-02-22T00:01"
     })
-    assert res.status_code == 401 # No permission to post
+    assert res.status_code == 302 # No permission to post
+    res = client.get(f"/auth/login")
+    assert b"It appears you are not signed in. Please sign in here." in res.data
+
 
 # Test unauthorized use of routes
 


### PR DESCRIPTION
This adds the functional sign up page to the site.
It also adjusts flask_login to redirect users to login rather than presenting a 401 error.
Along side the last feature the _next_ functionality now works, so users will be redirected back to what they were trying to access before being redirected.