### PR TITLE
Enabled cascading delete when a list is deleted

### DIFF
--- a/models/list.py
+++ b/models/list.py
@@ -11,4 +11,4 @@ class List(db.Model):
     user = db.relationship("User", back_populates="lists")
     
     # Link to Todo items
-    todos = db.relationship("Todo", back_populates="rem_list")
+    todos = db.relationship("Todo", back_populates="rem_list", cascade="all, delete")


### PR DESCRIPTION
This makes it so there are no reminders sin the database without a corresponding list. Forgot to turn this on earlier